### PR TITLE
Update it.xml

### DIFF
--- a/localization/it.xml
+++ b/localization/it.xml
@@ -237,7 +237,6 @@
     <state name="Cagliari" iso_code="CA" country="IT" zone="Europe"/>
     <state name="Caltanissetta" iso_code="CL" country="IT" zone="Europe"/>
     <state name="Campobasso" iso_code="CB" country="IT" zone="Europe"/>
-    <state name="Carbonia-Iglesias" iso_code="CI" country="IT" zone="Europe"/>
     <state name="Caserta" iso_code="CE" country="IT" zone="Europe"/>
     <state name="Catania" iso_code="CT" country="IT" zone="Europe"/>
     <state name="Catanzaro" iso_code="CZ" country="IT" zone="Europe"/>
@@ -269,25 +268,22 @@
     <state name="Lucca" iso_code="LU" country="IT" zone="Europe"/>
     <state name="Macerata" iso_code="MC" country="IT" zone="Europe"/>
     <state name="Mantova" iso_code="MN" country="IT" zone="Europe"/>
-    <state name="Massa" iso_code="MS" country="IT" zone="Europe"/>
+    <state name="Massa-Carrara" iso_code="MS" country="IT" zone="Europe"/>
     <state name="Matera" iso_code="MT" country="IT" zone="Europe"/>
-    <state name="Medio Campidano" iso_code="VS" country="IT" zone="Europe"/>
     <state name="Messina" iso_code="ME" country="IT" zone="Europe"/>
     <state name="Milano" iso_code="MI" country="IT" zone="Europe"/>
     <state name="Modena" iso_code="MO" country="IT" zone="Europe"/>
-    <state name="Monza e della Brianza" iso_code="MB" country="IT" zone="Europe"/>
+    <state name="Monza e Brianza" iso_code="MB" country="IT" zone="Europe"/>
     <state name="Napoli" iso_code="NA" country="IT" zone="Europe"/>
     <state name="Novara" iso_code="NO" country="IT" zone="Europe"/>
     <state name="Nuoro" iso_code="NU" country="IT" zone="Europe"/>
-    <state name="Ogliastra" iso_code="OG" country="IT" zone="Europe"/>
-    <state name="Olbia-Tempio" iso_code="OT" country="IT" zone="Europe"/>
     <state name="Oristano" iso_code="OR" country="IT" zone="Europe"/>
     <state name="Padova" iso_code="PD" country="IT" zone="Europe"/>
     <state name="Palermo" iso_code="PA" country="IT" zone="Europe"/>
     <state name="Parma" iso_code="PR" country="IT" zone="Europe"/>
     <state name="Pavia" iso_code="PV" country="IT" zone="Europe"/>
     <state name="Perugia" iso_code="PG" country="IT" zone="Europe"/>
-    <state name="Pesaro-Urbino" iso_code="PU" country="IT" zone="Europe"/>
+    <state name="Pesaro e Urbino" iso_code="PU" country="IT" zone="Europe"/>
     <state name="Pescara" iso_code="PE" country="IT" zone="Europe"/>
     <state name="Piacenza" iso_code="PC" country="IT" zone="Europe"/>
     <state name="Pisa" iso_code="PI" country="IT" zone="Europe"/>
@@ -309,6 +305,7 @@
     <state name="Siena" iso_code="SI" country="IT" zone="Europe"/>
     <state name="Siracusa" iso_code="SR" country="IT" zone="Europe"/>
     <state name="Sondrio" iso_code="SO" country="IT" zone="Europe"/>
+	<state name="Sud Sardegna" iso_code="SU" country="IT" zone="Europe"/>
     <state name="Taranto" iso_code="TA" country="IT" zone="Europe"/>
     <state name="Teramo" iso_code="TE" country="IT" zone="Europe"/>
     <state name="Terni" iso_code="TR" country="IT" zone="Europe"/>
@@ -316,7 +313,7 @@
     <state name="Trapani" iso_code="TP" country="IT" zone="Europe"/>
     <state name="Trento" iso_code="TN" country="IT" zone="Europe"/>
     <state name="Treviso" iso_code="TV" country="IT" zone="Europe"/>
-    <state name="Trieste" iso_code="TS" country="IT" zone="Europe"/>
+	<state name="Trieste" iso_code="TS" country="IT" zone="Europe"/>
     <state name="Udine" iso_code="UD" country="IT" zone="Europe"/>
     <state name="Varese" iso_code="VA" country="IT" zone="Europe"/>
     <state name="Venezia" iso_code="VE" country="IT" zone="Europe"/>


### PR DESCRIPTION
update italian states.
Added:
Sud Sardegna

removed:
> Carbonia-Iglesias
> Medio Campidano
> Olbia-Tempio
(those go to new state called "Sud Sardegna")
> Ogliastra (now it is in "Nuoro")

update names:
> Massa => Massa-Carrara
> Monza e della Brianza => Monza e Brianza
> Pesaro-Urbino => Pesaro e Urbino

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.7.7.x
| Description?  | I fix some italian states changed around 2016
| Type?         | bug fix
| Category?     | FO / BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no ticket
| How to test?  | You can see here https://it.wikipedia.org/wiki/Province_d%27Italia

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
